### PR TITLE
Add Lumenaut only Forum helpers and Wololo

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -4,6 +4,7 @@ if (isDev)
   require('dotenv').config()
 
 const userVerification = require('./user-verification')
+const wololo = require('./wololo')
 const { Client, Partials, GatewayIntentBits } = require('discord.js')
 
 const client = new Client({
@@ -24,12 +25,19 @@ const client = new Client({
 
 client.on('ready', async () => {
   await userVerification.setupVerificationChannel(client)
+  await wololo.setup(client)
 })
 
 client.on('interactionCreate', async interaction => {
-  if (interaction.customId == 'verify-user') {
+  if (interaction.customId == userVerification.interactionCustomId) {
     userVerification.handleVerification(interaction).catch(console.error)
   }
+
+  if (interaction.commandName == wololo.commandName) {
+    wololo.handleInteraction(interaction).catch(console.error)
+  }
+
+
 })
 
 client.login(process.env.DISCORD_BOT_TOKEN)

--- a/bot.js
+++ b/bot.js
@@ -19,28 +19,11 @@ const client = new Client({
     GatewayIntentBits.GuildMembers,
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.GuildMessageReactions,
-    GatewayIntentBits.MessageContent,
   ]
 })
 
-client.on('raw', async (packet) => {
-  try {
-    const { t: type } = packet
-    // console.log(packet)
-
-    switch (type) {
-      case 'READY':
-        await userVerification.setupVerificationChannel(client)
-      break
-
-      default:
-      return
-    }
-  }
-
-  catch(err) {
-    console.error(err)
-  }
+client.on('ready', async () => {
+  await userVerification.setupVerificationChannel(client)
 })
 
 client.on('interactionCreate', async interaction => {

--- a/bot.js
+++ b/bot.js
@@ -6,6 +6,7 @@ if (isDev)
 const userVerification = require('./user-verification')
 const wololo = require('./wololo')
 const { Client, Partials, GatewayIntentBits } = require('discord.js')
+const forum = require('./forum')
 
 const client = new Client({
   partials: [
@@ -26,6 +27,7 @@ const client = new Client({
 client.on('ready', async () => {
   await userVerification.setupVerificationChannel(client)
   await wololo.setup(client)
+  await forum.setup(client)
 })
 
 client.on('interactionCreate', async interaction => {
@@ -36,8 +38,6 @@ client.on('interactionCreate', async interaction => {
   if (interaction.commandName == wololo.commandName) {
     wololo.handleInteraction(interaction).catch(console.error)
   }
-
-
 })
 
 client.login(process.env.DISCORD_BOT_TOKEN)

--- a/db.js
+++ b/db.js
@@ -1,0 +1,2 @@
+const { PrismaClient } = require('@prisma/client')
+module.exports = new PrismaClient()

--- a/forum.js
+++ b/forum.js
@@ -1,0 +1,143 @@
+const { Client, ApplicationCommandType, ApplicationCommandOptionType, MessageFlags, PermissionFlagsBits } = require('discord.js')
+
+module.exports.commandName = 'post'
+
+module.exports.setup = async function setupForum(client) {
+  client.on('messageCreate', handleMessage)
+    .on('threadCreate', handlePost)
+    .on('interactionCreate', interaction => {
+      if (interaction.commandName == module.exports.commandName)
+        handleInteraction(interaction).catch(console.error)
+    })
+
+  const commands = await client.application.commands.fetch()
+  const command = commands.find(cmd => cmd.name == module.exports.commandName)
+  if (!command) {
+    await client.application.commands.create({
+      defaultMemberPermissions: PermissionFlagsBits.ManageMessages,
+      name: module.exports.commandName,
+      description: 'Different actions for forum threads',
+      type: ApplicationCommandType.ChatInput,
+      dm_permission: false,
+      options: [{
+        type: ApplicationCommandOptionType.Subcommand,
+        name: 'solve',
+        description: 'Tag this post as solved'
+      }, {
+        type: ApplicationCommandOptionType.Subcommand,
+        name: 'close',
+        description: 'Tag this post as solved and close it'
+      }, {
+        type: ApplicationCommandOptionType.Subcommand,
+        name: 'lock',
+        description: 'Lock and tag the post as solved. Note: only Lumenary+ will be able to reopen it.'
+      }, {
+        type: ApplicationCommandOptionType.Subcommand,
+        name: 'duplicate',
+        description: 'Toggle the posts duplicated tag.'
+      }, {
+        type: ApplicationCommandOptionType.Subcommand,
+        name: 'bug',
+        description: 'Toggle the solved tag.'
+      },{
+        type: ApplicationCommandOptionType.Subcommand,
+        name: 'flag',
+        description: 'Toggle the flagged tag.'
+      }]
+    })
+  }
+
+}
+
+/**
+ * Removes the open tag, when a lumenaut answered within a post.
+ */
+async function handleMessage(message) {
+  const channel = message.channel
+  if (!channel.isThread
+    || channel.parentId != process.env.FORUM_CHANNEL_HELP)
+    return
+  if (message.member?.roles?.cache.has(process.env.LUMENAUT_ROLE_ID)
+    && channel.appliedTags.includes(process.env.HELP_TAG_OPEN)) {
+    await channel.setAppliedTags(
+      channel.appliedTags.filter(
+        tag => tag != process.env.HELP_TAG_OPEN
+      ),
+      'Lumenaut answered post.'
+    )
+  }
+}
+
+
+const toggle = (tags, tag) => {
+  let idx;
+  if ((idx = tags.indexOf(tag)) >= 0)
+    tags.splice(idx, 1)
+  else
+    tags.push(tag)
+}
+
+const ensureTag = (tags, tag) => {
+  if (!tags.includes(tag))
+    tags.push(tag)
+}
+
+async function handleInteraction(interaction) {
+  if (!interaction.channel.isThread
+    || interaction.channel.parentId != process.env.FORUM_CHANNEL_HELP) {
+      return interaction.reply({
+        flags: MessageFlags.Ephemeral,
+        content: ':x: Invalid Channel'
+      })
+    }
+
+    const actor = `${interaction.member.user.username}#${interaction.member.user.tag}`
+    const tags = interaction.channel.appliedTags
+
+    // we need to reply before doing anything
+    // otherwise we'd reopen the post by writing to it ...
+    await interaction.reply({
+      flags: MessageFlags.Ephemeral,
+      content: ':white_check_mark: Processing.'
+
+    })
+    switch (interaction.options.getSubcommand(true)) {
+      case 'close':
+          ensureTag(tags, process.env.HELP_TAG_SOLVED)
+          await interaction.channel.setAppliedTags(tags, `Closed by ${actor}`)
+          await interaction.channel.setArchived(true)
+        break;
+      case 'solve':
+          toggle(tags, process.env.HELP_TAG_SOLVED)
+          await interaction.channel.setAppliedTags(tags, `Solved tag toggled by ${actor}`)
+        break;
+      case 'lock':
+        ensureTag(tags, process.env.HELP_TAG_SOLVED)
+        await interaction.channel.setAppliedTags(tags, `Locked by ${actor}`)
+        await interaction.channel.setLocked(true)
+        await interaction.channel.setArchived(true)
+        break;
+      case 'duplicate':
+          toggle(tags, process.env.HELP_TAG_DUPLICATE)
+          await interaction.channel.setAppliedTags(tags, `Duplicate tag toggled by ${actor}`)
+        break;
+      case 'bug':
+          toggle(tags, process.env.HELP_TAG_BUG)
+          await interaction.channel.setAppliedTags(tags, `Bug tag toggled by ${actor}`)
+        break;
+      case 'flag':
+          toggle(tags, process.env.HELP_TAG_FLAGGED)
+          await interaction.channel.setAppliedTags(tags, `Flagged tag toggled by ${actor}`)
+        break;
+    }
+}
+
+/**
+ * Sets the open tag to a new forum post
+ */
+async function handlePost(thread) {
+  if (thread.parentId != process.env.FORUM_CHANNEL_HELP
+    || thread.appliedTags.length)
+    return
+  await thread.setAppliedTags([process.env.HELP_TAG_OPEN], 'Help post created.')
+}

--- a/forum.js
+++ b/forum.js
@@ -2,6 +2,17 @@ const { Client, ApplicationCommandType, ApplicationCommandOptionType, MessageFla
 
 module.exports.commandName = 'post'
 
+const {
+  FORUM_CHANNEL_HELP,
+  LUMENAUT_ROLE_ID,
+  HELP_TAG_BUG,
+  HELP_TAG_DUPLICATE,
+  HELP_TAG_FLAGGED,
+  HELP_TAG_NEW,
+  HELP_TAG_OPEN,
+  HELP_TAG_SOLVED
+} = process.env
+
 module.exports.setup = async function setupForum(client) {
   client.on('messageCreate', handleMessage)
     .on('threadCreate', handlePost)
@@ -39,10 +50,14 @@ module.exports.setup = async function setupForum(client) {
         type: ApplicationCommandOptionType.Subcommand,
         name: 'bug',
         description: 'Toggle the solved tag.'
-      },{
+      }, {
         type: ApplicationCommandOptionType.Subcommand,
         name: 'flag',
         description: 'Toggle the flagged tag.'
+      }, {
+        type: ApplicationCommandOptionType.Subcommand,
+        name: 'open',
+        description: 'Tag this post as open and remove the solved tag is set.'
       }]
     })
   }
@@ -55,14 +70,15 @@ module.exports.setup = async function setupForum(client) {
 async function handleMessage(message) {
   const channel = message.channel
   if (!channel.isThread
-    || channel.parentId != process.env.FORUM_CHANNEL_HELP)
+    || channel.parentId != FORUM_CHANNEL_HELP)
     return
-  if (message.member?.roles?.cache.has(process.env.LUMENAUT_ROLE_ID)
-    && channel.appliedTags.includes(process.env.HELP_TAG_OPEN)) {
+  if (message.member?.roles?.cache.has(LUMENAUT_ROLE_ID)
+    && channel.appliedTags.includes(HELP_TAG_NEW)) {
+    const tags = channel.appliedTags
+    removeTag(tags, HELP_TAG_NEW)
+    addTag(tags, HELP_TAG_OPEN)
     await channel.setAppliedTags(
-      channel.appliedTags.filter(
-        tag => tag != process.env.HELP_TAG_OPEN
-      ),
+      tags,
       'Lumenaut answered post.'
     )
   }
@@ -82,62 +98,76 @@ const ensureTag = (tags, tag) => {
     tags.push(tag)
 }
 
+const removeTag = (tags, tag) => {
+  let idx;
+  if ((idx = tags.indexOf(tag)) >= 0)
+    tags.splice(idx, 1)
+}
+
 async function handleInteraction(interaction) {
   if (!interaction.channel.isThread
     || interaction.channel.parentId != process.env.FORUM_CHANNEL_HELP) {
-      return interaction.reply({
-        flags: MessageFlags.Ephemeral,
-        content: ':x: Invalid Channel'
-      })
-    }
-
-    const actor = `${interaction.member.user.username}#${interaction.member.user.tag}`
-    const tags = interaction.channel.appliedTags
-
-    // we need to reply before doing anything
-    // otherwise we'd reopen the post by writing to it ...
-    await interaction.reply({
+    return interaction.reply({
       flags: MessageFlags.Ephemeral,
-      content: ':white_check_mark: Processing.'
-
+      content: ':x: Invalid Channel'
     })
-    switch (interaction.options.getSubcommand(true)) {
-      case 'close':
-          ensureTag(tags, process.env.HELP_TAG_SOLVED)
-          await interaction.channel.setAppliedTags(tags, `Closed by ${actor}`)
-          await interaction.channel.setArchived(true)
-        break;
-      case 'solve':
-          toggle(tags, process.env.HELP_TAG_SOLVED)
-          await interaction.channel.setAppliedTags(tags, `Solved tag toggled by ${actor}`)
-        break;
-      case 'lock':
-        ensureTag(tags, process.env.HELP_TAG_SOLVED)
-        await interaction.channel.setAppliedTags(tags, `Locked by ${actor}`)
-        await interaction.channel.setLocked(true)
-        await interaction.channel.setArchived(true)
-        break;
-      case 'duplicate':
-          toggle(tags, process.env.HELP_TAG_DUPLICATE)
-          await interaction.channel.setAppliedTags(tags, `Duplicate tag toggled by ${actor}`)
-        break;
-      case 'bug':
-          toggle(tags, process.env.HELP_TAG_BUG)
-          await interaction.channel.setAppliedTags(tags, `Bug tag toggled by ${actor}`)
-        break;
-      case 'flag':
-          toggle(tags, process.env.HELP_TAG_FLAGGED)
-          await interaction.channel.setAppliedTags(tags, `Flagged tag toggled by ${actor}`)
-        break;
-    }
+  }
+
+  const actor = `${interaction.member.user.username}#${interaction.member.user.tag}`
+  const tags = interaction.channel.appliedTags
+
+  // we need to reply before doing anything
+  // otherwise we'd reopen the post by writing to it ...
+  await interaction.reply({
+    flags: MessageFlags.Ephemeral,
+    content: ':white_check_mark: Processing.'
+
+  })
+  switch (interaction.options.getSubcommand(true)) {
+    case 'close':
+      removeTag(tags, HELP_TAG_OPEN)
+      ensureTag(tags, HELP_TAG_SOLVED)
+      await interaction.channel.setAppliedTags(tags, `Closed by ${actor}`)
+      await interaction.channel.setArchived(true)
+      break
+    case 'solve':
+      removeTag(tags, HELP_TAG_OPEN)
+      toggle(tags, HELP_TAG_SOLVED)
+      await interaction.channel.setAppliedTags(tags, `Solved tag toggled by ${actor}`)
+      break
+    case 'lock':
+      removeTag(tags, HELP_TAG_OPEN)
+      ensureTag(tags, HELP_TAG_SOLVED)
+      await interaction.channel.setAppliedTags(tags, `Locked by ${actor}`)
+      await interaction.channel.setLocked(true)
+      await interaction.channel.setArchived(true)
+      break
+    case 'duplicate':
+      toggle(tags, HELP_TAG_DUPLICATE)
+      await interaction.channel.setAppliedTags(tags, `Duplicate tag toggled by ${actor}`)
+      break
+    case 'bug':
+      toggle(tags, HELP_TAG_BUG)
+      await interaction.channel.setAppliedTags(tags, `Bug tag toggled by ${actor}`)
+      break
+    case 'flag':
+      toggle(tags, HELP_TAG_FLAGGED)
+      await interaction.channel.setAppliedTags(tags, `Flagged tag toggled by ${actor}`)
+      break
+    case 'open':
+      removeTag(tags, HELP_TAG_SOLVED)
+      ensureTag(tags, HELP_TAG_OPEN)
+      await interaction.channel.setAppliedTags(tags, `Post opened by ${actor}`)
+      break
+  }
 }
 
 /**
- * Sets the open tag to a new forum post
+ * Sets the new tag to a new forum post
  */
 async function handlePost(thread) {
-  if (thread.parentId != process.env.FORUM_CHANNEL_HELP
+  if (thread.parentId != FORUM_CHANNEL_HELP
     || thread.appliedTags.length)
     return
-  await thread.setAppliedTags([process.env.HELP_TAG_OPEN], 'Help post created.')
+  await thread.setAppliedTags([HELP_TAG_NEW], 'Help post created.')
 }

--- a/forum.js
+++ b/forum.js
@@ -113,7 +113,7 @@ async function handleInteraction(interaction) {
     })
   }
 
-  const actor = `${interaction.member.user.username}#${interaction.member.user.tag}`
+  const actor = interaction.member.user.tag
   const tags = interaction.channel.appliedTags
 
   // we need to reply before doing anything
@@ -121,7 +121,6 @@ async function handleInteraction(interaction) {
   await interaction.reply({
     flags: MessageFlags.Ephemeral,
     content: ':white_check_mark: Processing.'
-
   })
   switch (interaction.options.getSubcommand(true)) {
     case 'close':

--- a/prisma/migrations/20221116211513_wololo/migration.sql
+++ b/prisma/migrations/20221116211513_wololo/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "Wololo" (
+    "id" SERIAL NOT NULL,
+    "trigger" TEXT NOT NULL,
+    "wololo" TEXT NOT NULL,
+    "at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Wololo_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "Wololo_wololo_key" ON "Wololo"("wololo");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,3 +14,10 @@ model VerifiedUser {
   id String @id // Discord ID 
   verifiedAt DateTime @default(now())
 }
+
+model Wololo {
+  id Int @id @default(autoincrement())
+  trigger String
+  wololo String @unique
+  at DateTime @default(now())
+}

--- a/user-verification.js
+++ b/user-verification.js
@@ -1,9 +1,10 @@
-const { PrismaClient } = require('@prisma/client')
 const fetch = require('node-fetch')
 const { ComponentType, ButtonStyle, MessageFlags } = require('discord.js')
 const { isBefore, addWeeks } = require('date-fns')
 
-const db = new PrismaClient()
+const db = require('./db')
+
+module.exports.interactionCustomId = 'verify-user'
 
 // Sets up a message in process.env.VERIFICATION_CHANNEL_ID if this channel is empty
 module.exports.setupVerificationChannel = async function setupVerificationChannel(client) {
@@ -21,12 +22,14 @@ Once you've done so just press the button below!`,
           type: ComponentType.Button,
           style: ButtonStyle.Primary,
           label: 'Verify Me',
-          custom_id: 'verify-user'
+          custom_id: module.exports.interactionCustomId
         }]
       }]
     })
   }
 }
+
+
 
 module.exports.handleVerification = async function handleVerification(interaction) {
   const { id } = interaction.member.user

--- a/wololo.js
+++ b/wololo.js
@@ -1,0 +1,69 @@
+const { ApplicationCommandType, ApplicationCommandOptionType, MessageFlags } = require('discord.js')
+const fetch = require('node-fetch')
+
+const db = require('./db')
+
+module.exports.commandName = 'wololo'
+
+module.exports.setup = async function wololoSetuo(client) {
+  const commands = await client.application.commands.fetch()
+  const existingCommand = commands.find(cmd => cmd.name == module.exports.commandName)
+  if (!existingCommand) {
+    await client.application.commands.create({
+      name: module.exports.commandName,
+      type: ApplicationCommandType.ChatInput,
+      description: module.exports.commandName,
+      dmPermission: false,
+      options: [{
+        name: module.exports.commandName,
+        description: module.exports.commandName,
+        type: ApplicationCommandOptionType.String,
+        focused: true,
+        required: true
+      }]
+    })
+  }
+}
+
+module.exports.handleInteraction = async function handleWololoInteraction(interaction) {
+  let wololo = interaction.options.getString(module.exports.commandName, true)
+  if (await db.wololo.findFirst({
+    where: {
+      wololo
+    }
+  })) {
+    await interaction.reply({
+      flags: MessageFlags.Ephemeral,
+      content: ':white_check_mark: Already done.'
+    })
+    return
+  }
+
+  const res = await fetch(`https://api.stellar.quest/utils/wololo/${wololo}`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${process.env.WOLOLO_KEY}`
+    }
+  })
+
+  if (res.ok) {
+    await Promise.all([
+      interaction.reply({
+        flags: MessageFlags.Ephemeral,
+        content: ':white_check_mark: Success.'
+      }),
+      db.wololo.create({
+        data: {
+          wololo,
+          trigger: interaction.member.user.id
+        }
+      })
+    ])
+    return
+  }
+
+  await interaction.reply({
+    flags: MessageFlags.Ephemeral,
+    conten: ':x: Failure.'
+  })
+}

--- a/wololo.js
+++ b/wololo.js
@@ -1,4 +1,4 @@
-const { ApplicationCommandType, ApplicationCommandOptionType, MessageFlags } = require('discord.js')
+const { ApplicationCommandType, ApplicationCommandOptionType, MessageFlags, PermissionFlagsBits } = require('discord.js')
 const fetch = require('node-fetch')
 
 const db = require('./db')
@@ -14,6 +14,7 @@ module.exports.setup = async function wololoSetuo(client) {
       type: ApplicationCommandType.ChatInput,
       description: module.exports.commandName,
       dmPermission: false,
+      defaultMemberPermissions: PermissionFlagsBits.ManageMessages,
       options: [{
         name: module.exports.commandName,
         description: module.exports.commandName,


### PR DESCRIPTION
Shorty after the release of a live quest, our Help channel gets flooded with posts.
These are hard to manage because you only can filter for the existence of a tag, not the lack of it.

The bot solves this problem by tagging a post as "new" when it's created and transitions it to a "open" tag, when a Lumenaut sends a message within that post the first time.

This way we can prioritise truly new posts just by filtering and come back to posts still open later when things calm down.

Also adds a `/post`-command that can:
- close a post (aka. mark it archived)
- close and lock a post
these two will both also "solve" the post which means
- solve a post: add the solved tag and remove the open tag
- toggle the tags: duplicate, bug and flagged
- (re) open a post: removes the solved tag and adds the open tag

Right now Lumenauts can't edit tags at all and this automation should make it way easier to manage posts when things are busy!

I'll probably will need to iterate on things later and maybe add some commands that can be invoked by the author of the post, but this has been enough discord-edge-case pain for now.

This PR also adds more Wololo!

---

The Heroku Env has already been setup with the necessary Vars, only thing needed to get this version running:
- merging
- deploying
- before /wololo is used the first time running `npx prisma migrate deploy`
- setting up both commands so that Lumenauts can access them (and other users can't, but this should've been enforced by the default permissions)
- setting up permissions on /help so that the bot can manage Posts (I can do that later)